### PR TITLE
int to string comparison and centos needs fuse.conf user_allow_other

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,6 @@
 - name: restart autofs
   service: 
     name: autofs 
-    state: restarted$
+    state: restarted
   when: ansible_virtualization_type != "docker"
 ...

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -52,10 +52,3 @@
     name: cvmfs
     append: yes
     groups: fuse
-
-- name: lineinfile fuse.conf to enable user_allow_other
-  lineinfile:
-    dest: /etc/fuse.conf
-    regexp: '^user_allow_other$'
-    line: 'user_allow_other'
-    backup: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,13 @@
    when: ansible_os_family == "RedHat"
  - include: debian.yml
    when: ansible_os_family == "Debian"
-
 ## Common tasks
+ - name: lineinfile fuse.conf to enable user_allow_other
+   lineinfile:
+     dest: /etc/fuse.conf
+     regexp: '^user_allow_other$'
+     line: 'user_allow_other'
+     backup: yes
 
  - name: add a cms.cern.ch.local if cms_site is defined
    template:
@@ -40,7 +45,7 @@
      src: cvmfs.autofs
      dest: /etc/auto.master.d/cvmfs.autofs
      backup: yes
-   when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= "7") or ansible_os_family == "Debian"
+   when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Debian"
    notify: restart autofs
    register: autofsconfig
  


### PR DESCRIPTION
Hi, 

I get the following message from ansible 2.2.2.0 on the `template /etc/auto.master.d/cvmfs.autofs` task:
```

  Unexpected templating type error occurred on
  {% if (ansible_os_family == \"RedHat\" and 
      ansible_distribution_major_version|int >= \"7\") or 
      ansible_os_family == \"Debian\" %} 
    True 
  {% else %} 
    False 
  {% endif %}): 
  unorderable types: int() >= str()
```
I think it is comparing a string to an int, removing the quotes around "7" seems to fix it.

Also, I think there is a trailing $ in the restart handler `ansible-role-cvmfs : restart autofs`

Thank you for the role, it's really nice.

Signed-off-by: Ian Allison <iana@pims.math.ca>