### PR TITLE
Ansible 2.4 is here: include -> include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 # tasks file for ansible-role-cvmfs
 #
- - include: redhat.yml
+ - include_tasks: redhat.yml
    when: ansible_os_family == "RedHat"
- - include: debian.yml
+ - include_tasks: debian.yml
    when: ansible_os_family == "Debian"
 ## Common tasks
  - name: lineinfile fuse.conf to enable user_allow_other


### PR DESCRIPTION
Simple fix to kill the depreciation warnings for the use of include