### PR TITLE
install key via HTTPS

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -11,7 +11,7 @@
 
 - name: rpm_key CVMFS gpg key
   rpm_key:
-    key: http://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
+    key: https://cvmrepo.web.cern.ch/cvmrepo/yum/RPM-GPG-KEY-CernVM
     state: present
   register: cvmfs_cernrepokey
 


### PR DESCRIPTION
The GPG key is available via HTTPS; since it is the trust anchor for the installation of the CVMFS client and CVMFS repository contents, HTTP should be avoided.